### PR TITLE
Update SMC keys

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC     = clang
 PROG   = pmctl
-OBJS   = main.o smc.o assert.o power.o util.o
+OBJS   = main.o smc.o assert.o power.o util.o os.o
 CFLAGS = -mtune=native -O2 -Wall -I.
 FFLAGS = -framework Foundation -framework IOKit
 

--- a/os.m
+++ b/os.m
@@ -1,0 +1,14 @@
+#include <Foundation/Foundation.h>
+#include <stdio.h>
+#include <pmctl.h>
+
+struct osversion get_os_version()
+{
+	NSOperatingSystemVersion objv = [[NSProcessInfo processInfo] operatingSystemVersion];
+	struct osversion os = {
+		.majorVersion = objv.majorVersion,
+		.minorVersion = objv.minorVersion,
+		.patchVersion = objv.patchVersion,
+	};
+	return (os);
+}

--- a/pmctl.h
+++ b/pmctl.h
@@ -22,8 +22,14 @@
 
 #define smcBatteryMax			'BCLM'
 #define smcBatteryChargingIntel		'CH0B'
-#define smcBatteryChargingApple		'CH0C'
-#define smcDisableInflow		'CH0I'
+#define smcBatteryChargingAppleLegacy	'CH0C'
+#define smcDisableInflowLegacy		'CH0I'
+#define smcBatteryChargingApple		'CHTE'
+#define smcDisableInflow		'CHIE'
+
+#define smcDisableInflowValueLegacy	1
+#define smcDisableInflowValueLatest	8
+
 
 struct options
 {       
@@ -34,6 +40,13 @@ struct options
 	cpu_type_t	cputype;
 };
 
+struct osversion
+{
+	int	majorVersion;
+	int	minorVersion;
+	int	patchVersion;
+};
+
 /* smc.c */
 int		smc_write(uint32_t, uint8_t);
 int		smc_read(uint32_t);
@@ -42,6 +55,9 @@ IOReturn	callSMCFunction(int, SMCParamStruct *, SMCParamStruct *);
 /* assert.c */
 IOPMAssertionID		assert_create(CFStringRef, const char *);
 int			assert_inflow_disable(uint8_t);
+
+/* os.m */
+struct osversion	get_os_version();
 
 /* power.c */
 int			pwr_battery_soc(int);

--- a/smc.c
+++ b/smc.c
@@ -92,11 +92,13 @@ smc_read(uint32_t key) {
 			    smc[1].bytes[0]);
 			break;
 		case smcBatteryChargingApple:
+		case smcBatteryChargingAppleLegacy:
 		case smcBatteryChargingIntel:
 			printf("smcBatteryCharging	%s\n",
 			    smc[1].bytes[0] == 0 ? "enabled" : "disabled");
 			break;
 		case smcDisableInflow:
+		case smcDisableInflowLegacy:
 			printf("smcDisableInflow	%s\n",
 			    smc[1].bytes[0] == 0 ? "disabled" : "enabled");
 			break;


### PR DESCRIPTION
New SMC keys are required when using a more recent macOS version.